### PR TITLE
Remove shard_runtime arg that the function doesn't take anymore

### DIFF
--- a/benchmark_flops/flops_benchmark.py
+++ b/benchmark_flops/flops_benchmark.py
@@ -18,7 +18,7 @@ def benchmark(loopcount, workers, matn, verbose=False):
     def f(x):
         return {'flops' : compute_flops(loopcount, matn)}
 
-    pwex = pywren.lambda_executor(shard_runtime=True) 
+    pwex = pywren.lambda_executor()
     futures = pwex.map(f, iters)
 
     print("invocation done, dur=", time.time() - t1)

--- a/benchmark_s3/s3_benchmark.py
+++ b/benchmark_s3/s3_benchmark.py
@@ -40,7 +40,7 @@ def write(bucket_name, mb_per_file, number, key_prefix,
         mb_rate = bytes_n/(t2-t1)/1e6
         return t1, t2, mb_rate
 
-    wrenexec = pywren.default_executor(shard_runtime=True)
+    wrenexec = pywren.default_executor()
 
     # create list of random keys
     keynames = [ key_prefix + str(uuid.uuid4().get_hex().upper()) for _ in range(number)]
@@ -88,7 +88,7 @@ def read(bucket_name, number,
         mb_rate = bytes_read/(t2-t1)/1e6
         return t1, t2, mb_rate, bytes_read, a
 
-    wrenexec = pywren.default_executor(shard_runtime=True)
+    wrenexec = pywren.default_executor()
     if number == 0:
         keylist = keylist_raw
     else:


### PR DESCRIPTION
`shard_runtime` isn't in the function signature for `lambda_executor` and `default _executor`, so the example crashes. 

See https://github.com/pywren/pywren/commit/513dbb36b134c68b647f5239afae5716e017e1c7