### PR TITLE
Use poetry to manage dependencies and virtualenv

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
 .ipynb_checkpoints
 *.pyc
 *~
+
+# Ignore the poetry dependency lock
+poetry.lock
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,32 @@
+[tool.poetry]
+name = "pywren_examples"
+version = "0.1.0"
+description = ""
+authors = ["Your Name <you@example.com>"]
+
+[tool.poetry.dependencies]
+python = "^3.6"
+boto3 = "^1.9"
+click = "^7.0"
+jupyter = "^1.0"
+ntplib = "^0.3.3"
+numpy = "^1.16"
+pandas = "^0.24.2"
+pywren = "^0.4.0"
+requests = "^2.22"
+ruffus = "^2.8"
+scikit-learn = "^0.21.2"
+
+[tool.poetry.dev-dependencies]
+black = {version = "^18.3-alpha.0",allows-prereleases = true}
+ipdb = "*"
+pylint = "*"
+pytest = "*"
+
+[tool.black]
+line-length = 96
+
+[build-system]
+requires = ["poetry>=0.12"]
+build-backend = "poetry.masonry.api"
+


### PR DESCRIPTION
These dependencies were identified and curated starting with:
```
git grep import | grep ':import' | sed -e 's/.*:import //' | sort -u > requirements.txt
```

The pywren project should be OK with ^py34 but this uses ^py36, no particular reason.
